### PR TITLE
Update links to dnSpy fork since dnSpy is archived.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "dnSpy"]
 	path = dnSpy
-	url = https://github.com/dnSpy/dnSpy/
+	url = https://github.com/dnSpyEx/dnSpy/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dnSpy.Extension.DiscordRPC
 ==========================
 
-A [dnSpy](https://github.com/dnSpy/dnSpy) extension to add [Discord Rich Presence](https://discord.com/rich-presence) integration to dnSpy.
+A [dnSpy](https://github.com/dnSpyEx/dnSpy) extension to add [Discord Rich Presence](https://discord.com/rich-presence) integration to dnSpy.
 
 ### Installation
 Download the latest release [here](https://github.com/holly-hacker/dnspy.extension.discordrpc/releases/latest) and follow the instructions [here](https://github.com/HoLLy-HaCKeR/dnSpy.Extension.HoLLy#installation).


### PR DESCRIPTION
Update links to dnSpy fork since dnSpy is archived. 
Update dnSpy submodule version to v6.1.9